### PR TITLE
Add deploy to Netlify button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Harp’s Blog Boilerplate
 
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/harp-boilerplates/hb-blog)
+
 _This is a boilerplate to use with the [Harp Platform](http://harp.io/) and/or the [Harp Server](http://harpjs.com/) (a static web server with built-in pre-processing build with NodeJS)_
 
 ## Index

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm install -g harp"
+  publish = "www"


### PR DESCRIPTION
I added a deploy to Netlify button to the README. Feel free to test it out below. The toml file just tells Netlify that your index.html is in the public www folder and your build command is harp compile. I did this, because I want to add a harp example to [http://www.staticgen.com/](http://www.staticgen.com/) and this would help. The deploy button in the readme is just a bonus.

Netlify also has a liberal [Open Source](https://www.netlify.com/open-source/) plan for all open source projects, in case you had some other harp examples you would like to host there.


<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/hb-blog)